### PR TITLE
Update Jade to 1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "colors": "0.6.2",
     "commander": "1.2.0",
     "glob": "3.2.6",
-    "jade": "~0.34.1"
+    "jade": "~1.9.2"
   },
   "devDependencies": {
     "coffee-script": "1.6.3"


### PR DESCRIPTION
I have a very similar bug to #9 that is caused by this specific markup

```jade
script.
	(function () {
		if (anyVariable) {}
		// any comment
	})();
```

It's fixed by simply bumping Jade to [0.35.0](https://github.com/jadejs/jade/releases), which is exactly the next version.

I also tried 1.8.2 and the whole build works fine too, so we might as well update Jade to that.